### PR TITLE
docs: fix simple typo, relationshops -> relationships

### DIFF
--- a/recsys/datamodel/data.py
+++ b/recsys/datamodel/data.py
@@ -9,7 +9,7 @@ from recsys.algorithm import VERBOSE
 
 class Data:
     """
-    Handles the relationshops among users and items
+    Handles the relationships among users and items
     """
     def __init__(self):
         #"""


### PR DESCRIPTION
There is a small typo in recsys/datamodel/data.py.

Should read `relationships` rather than `relationshops`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md